### PR TITLE
Add support for Ollama, Palm, Claude-2, Cohere, Replicate Llama2, Hugging Face TGI (100+LLMs) [LiteLLM]

### DIFF
--- a/evals/utils/api_utils.py
+++ b/evals/utils/api_utils.py
@@ -7,6 +7,7 @@ import os
 
 import backoff
 import openai
+import litellm
 
 EVALS_THREAD_TIMEOUT = float(os.environ.get("EVALS_THREAD_TIMEOUT", "40"))
 
@@ -66,7 +67,7 @@ def openai_chat_completion_create_retrying(*args, **kwargs):
     Helper function for creating a chat completion.
     `args` and `kwargs` match what is accepted by `openai.ChatCompletion.create`.
     """
-    result = request_with_timeout(openai.ChatCompletion.create, *args, **kwargs)
+    result = request_with_timeout(litellm.completion, *args, **kwargs)
     if "error" in result:
         logging.warning(result)
         raise openai.error.APIError(result["error"])

--- a/evals/utils/azure_utils.py
+++ b/evals/utils/azure_utils.py
@@ -5,6 +5,7 @@ import time
 
 import backoff
 import openai
+import litellm
 
 EVALS_THREAD_TIMEOUT = float(os.environ.get("EVALS_THREAD_TIMEOUT", "40"))
 SLEEP_TIME = float(
@@ -75,7 +76,7 @@ def azure_chat_completion_create_retrying(GPT_4: bool = False,
     """
     openai.api_base = "API-BASE"
     openai.api_key = "API-KEY"
-    result = request_with_timeout(openai.ChatCompletion.create, *args, **kwargs)
+    result = request_with_timeout(litellm.completion, *args, **kwargs)
     time.sleep(SLEEP_TIME)
     if "error" in result:
         logging.warning(result)

--- a/evals/utils/theoremqa_utils.py
+++ b/evals/utils/theoremqa_utils.py
@@ -5,6 +5,7 @@ from time import sleep
 
 import numpy as np
 import openai
+import litellm
 import wolframalpha
 from sympy import Rational
 
@@ -66,7 +67,7 @@ Input: {query}
 Output:"""
     while not got_result:
         try:
-            result = openai.ChatCompletion.create(
+            result = litellm.completion(
                 **kwargs,
                 messages=[
                     {"role": "system", "content": SYSTEMQ},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires-python = ">=3.9"
 dependencies = [
     "mypy",
     "openai == 0.27.8",
+    "litellm",
     "tiktoken",
     "blobfile",
     "backoff",


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 


Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```